### PR TITLE
Add optional utilities module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,12 @@
 
 `kiora` is a Java utility library aimed at reducing repetitive code in everyday applications.
 
-The first feature in the library is path-based access for nested `Map<String, Object>` and `List<?>` structures. It targets the gap between:
+The library currently includes two focused packages:
 
-- raw `Map` traversal with repetitive casts and null checks
-- full JSON binding when the payload is dynamic and not worth modeling yet
+- `io.github.amatriciaaana.kiora.path` for safe access to nested `Map<String, Object>` and `List<?>` structures
+- `io.github.amatriciaaana.kiora.result` for lightweight success/failure handling around exception-heavy code
 
-## Current Scope
-
-The current package is `io.github.amatriciaaana.kiora.path`.
-
-It provides:
-
-- `DeepMap` for safe nested lookup
-- `PathSyntaxException` for invalid path input
-
-The longer-term direction is to keep `kiora` broad enough to host additional small utilities beyond path access.
+The longer-term direction is to keep `kiora` broad enough to host additional small utilities without turning it into a framework.
 
 ## Requirements
 
@@ -25,19 +16,7 @@ The longer-term direction is to keep `kiora` broad enough to host additional sma
 
 That setup keeps the project aligned with the latest LTS while remaining easy to adopt in existing Java 17 environments.
 
-## Path Syntax
-
-- `user.profile.name`
-- `items[0].price`
-- `settings.flags.beta`
-
-Current constraints:
-
-- `.` separates map keys
-- `[n]` accesses list elements
-- map keys themselves must not contain `.` or `[]`
-
-## Example
+## Path Example
 
 ```java
 import io.github.amatriciaaana.kiora.path.DeepMap;
@@ -60,17 +39,33 @@ int price = deepMap.getInt("items[0].price").orElse(0);
 boolean hasCoupon = deepMap.hasPath("items[0].coupon");
 ```
 
-## API Surface
+## Result Example
 
-- `DeepMap.of(Map<String, ?> source)`
-- `Optional<Object> get(String path)`
-- `Optional<T> get(String path, Class<T> type)`
-- `Optional<String> getString(String path)`
-- `Optional<Integer> getInt(String path)`
-- `Optional<Boolean> getBoolean(String path)`
-- `Optional<DeepMap> getMap(String path)`
-- `boolean hasPath(String path)`
-- `Object require(String path)`
+```java
+import io.github.amatriciaaana.kiora.result.Result;
+import io.github.amatriciaaana.kiora.result.Try;
+
+Result<Integer> parsed = Try.of(() -> Integer.parseInt("42"))
+        .map(value -> value + 1);
+
+int value = parsed.orElse(0);
+```
+
+## Result API Surface
+
+- `Result.success(value)`
+- `Result.failure(cause)`
+- `boolean isSuccess()`
+- `boolean isFailure()`
+- `T orElse(T fallback)`
+- `T orElseGet(Function<Throwable, T> fallback)`
+- `T orElseThrow()`
+- `Optional<T> toOptional()`
+- `Result<R> map(Function<T, R> mapper)`
+- `Result<R> flatMap(Function<T, Result<R>> mapper)`
+- `Result<T> recover(Function<Throwable, T> recovery)`
+- `Try.of(...)`
+- `Try.run(...)`
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 `kiora` is a Java utility library aimed at reducing repetitive code in everyday applications.
 
-The library currently includes two focused packages:
+The library currently includes three focused packages:
 
 - `io.github.amatriciaaana.kiora.path` for safe access to nested `Map<String, Object>` and `List<?>` structures
 - `io.github.amatriciaaana.kiora.result` for lightweight success/failure handling around exception-heavy code
+- `io.github.amatriciaaana.kiora.optional` for small `Optional` helpers that remove repeated boilerplate
 
 The longer-term direction is to keep `kiora` broad enough to host additional small utilities without turning it into a framework.
 
@@ -51,21 +52,26 @@ Result<Integer> parsed = Try.of(() -> Integer.parseInt("42"))
 int value = parsed.orElse(0);
 ```
 
-## Result API Surface
+## Optional Example
 
-- `Result.success(value)`
-- `Result.failure(cause)`
-- `boolean isSuccess()`
-- `boolean isFailure()`
-- `T orElse(T fallback)`
-- `T orElseGet(Function<Throwable, T> fallback)`
-- `T orElseThrow()`
-- `Optional<T> toOptional()`
-- `Result<R> map(Function<T, R> mapper)`
-- `Result<R> flatMap(Function<T, Result<R>> mapper)`
-- `Result<T> recover(Function<Throwable, T> recovery)`
-- `Try.of(...)`
-- `Try.run(...)`
+```java
+import io.github.amatriciaaana.kiora.optional.MoreOptional;
+import io.github.amatriciaaana.kiora.result.Result;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+Optional<String> nickname = MoreOptional.or(Optional.empty(), () -> "guest");
+Optional<String> visible = MoreOptional.filterNot(nickname, String::isBlank);
+Result<String> required = MoreOptional.toResult(visible, () -> new NoSuchElementException("nickname"));
+```
+
+## Optional API Surface
+
+- `MoreOptional.ofNullable(value)`
+- `MoreOptional.or(optional, fallbackSupplier)`
+- `MoreOptional.filterNot(optional, predicate)`
+- `MoreOptional.toResult(optional, errorSupplier)`
+- `MoreOptional.streamOfNullable(value)`
 
 ## Build
 

--- a/src/main/java/io/github/amatriciaaana/kiora/optional/MoreOptional.java
+++ b/src/main/java/io/github/amatriciaaana/kiora/optional/MoreOptional.java
@@ -1,0 +1,43 @@
+package io.github.amatriciaaana.kiora.optional;
+
+import io.github.amatriciaaana.kiora.result.Result;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Small utility methods that make {@link Optional} composition less repetitive.
+ */
+public final class MoreOptional {
+    private MoreOptional() {
+    }
+
+    public static <T> Optional<T> ofNullable(T value) {
+        return Optional.ofNullable(value);
+    }
+
+    public static <T> Optional<T> or(Optional<T> optional, Supplier<? extends T> fallbackSupplier) {
+        Objects.requireNonNull(optional, "optional must not be null");
+        Objects.requireNonNull(fallbackSupplier, "fallbackSupplier must not be null");
+        return optional.isPresent() ? optional : Optional.ofNullable(fallbackSupplier.get());
+    }
+
+    public static <T> Optional<T> filterNot(Optional<T> optional, Predicate<? super T> predicate) {
+        Objects.requireNonNull(optional, "optional must not be null");
+        Objects.requireNonNull(predicate, "predicate must not be null");
+        return optional.filter(predicate.negate());
+    }
+
+    public static <T> Result<T> toResult(Optional<T> optional, Supplier<? extends Throwable> errorSupplier) {
+        Objects.requireNonNull(optional, "optional must not be null");
+        Objects.requireNonNull(errorSupplier, "errorSupplier must not be null");
+        return optional.<Result<T>>map(Result::success)
+                .orElseGet(() -> Result.failure(errorSupplier.get()));
+    }
+
+    public static <T> Stream<T> streamOfNullable(T value) {
+        return Optional.ofNullable(value).stream();
+    }
+}

--- a/src/main/java/io/github/amatriciaaana/kiora/result/Failure.java
+++ b/src/main/java/io/github/amatriciaaana/kiora/result/Failure.java
@@ -1,0 +1,72 @@
+package io.github.amatriciaaana.kiora.result;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Failed result cause.
+ *
+ * @param <T> value type
+ */
+public record Failure<T>(Throwable cause) implements Result<T> {
+
+    public Failure {
+        Objects.requireNonNull(cause, "cause must not be null");
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return false;
+    }
+
+    @Override
+    public T orElse(T fallback) {
+        return fallback;
+    }
+
+    @Override
+    public T orElseGet(Function<? super Throwable, ? extends T> fallback) {
+        Objects.requireNonNull(fallback, "fallback must not be null");
+        return fallback.apply(cause);
+    }
+
+    @Override
+    public T orElseThrow() {
+        if (cause instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        throw new ResultException(cause);
+    }
+
+    @Override
+    public Throwable errorOrNull() {
+        return cause;
+    }
+
+    @Override
+    public Optional<T> toOptional() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <R> Result<R> map(Function<? super T, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        return new Failure<>(cause);
+    }
+
+    @Override
+    public <R> Result<R> flatMap(Function<? super T, Result<R>> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        return new Failure<>(cause);
+    }
+
+    @Override
+    public Result<T> recover(Function<? super Throwable, ? extends T> recovery) {
+        Objects.requireNonNull(recovery, "recovery must not be null");
+        return Result.success(recovery.apply(cause));
+    }
+}

--- a/src/main/java/io/github/amatriciaaana/kiora/result/Result.java
+++ b/src/main/java/io/github/amatriciaaana/kiora/result/Result.java
@@ -1,0 +1,42 @@
+package io.github.amatriciaaana.kiora.result;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Represents either a success value or a failure cause.
+ *
+ * @param <T> value type
+ */
+public sealed interface Result<T> permits Success, Failure {
+
+    static <T> Result<T> success(T value) {
+        return new Success<>(value);
+    }
+
+    static <T> Result<T> failure(Throwable cause) {
+        return new Failure<>(cause);
+    }
+
+    boolean isSuccess();
+
+    default boolean isFailure() {
+        return !isSuccess();
+    }
+
+    T orElse(T fallback);
+
+    T orElseGet(Function<? super Throwable, ? extends T> fallback);
+
+    T orElseThrow();
+
+    Throwable errorOrNull();
+
+    Optional<T> toOptional();
+
+    <R> Result<R> map(Function<? super T, ? extends R> mapper);
+
+    <R> Result<R> flatMap(Function<? super T, Result<R>> mapper);
+
+    Result<T> recover(Function<? super Throwable, ? extends T> recovery);
+}

--- a/src/main/java/io/github/amatriciaaana/kiora/result/ResultException.java
+++ b/src/main/java/io/github/amatriciaaana/kiora/result/ResultException.java
@@ -1,0 +1,11 @@
+package io.github.amatriciaaana.kiora.result;
+
+/**
+ * Wraps checked exceptions when a failed result is converted back into a thrown exception.
+ */
+public final class ResultException extends RuntimeException {
+
+    public ResultException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/github/amatriciaaana/kiora/result/Success.java
+++ b/src/main/java/io/github/amatriciaaana/kiora/result/Success.java
@@ -1,0 +1,62 @@
+package io.github.amatriciaaana.kiora.result;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Successful result value.
+ *
+ * @param <T> value type
+ */
+public record Success<T>(T value) implements Result<T> {
+
+    @Override
+    public boolean isSuccess() {
+        return true;
+    }
+
+    @Override
+    public T orElse(T fallback) {
+        return value;
+    }
+
+    @Override
+    public T orElseGet(Function<? super Throwable, ? extends T> fallback) {
+        Objects.requireNonNull(fallback, "fallback must not be null");
+        return value;
+    }
+
+    @Override
+    public T orElseThrow() {
+        return value;
+    }
+
+    @Override
+    public Throwable errorOrNull() {
+        return null;
+    }
+
+    @Override
+    public Optional<T> toOptional() {
+        return Optional.ofNullable(value);
+    }
+
+    @Override
+    public <R> Result<R> map(Function<? super T, ? extends R> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        return Result.success(mapper.apply(value));
+    }
+
+    @Override
+    public <R> Result<R> flatMap(Function<? super T, Result<R>> mapper) {
+        Objects.requireNonNull(mapper, "mapper must not be null");
+        return Objects.requireNonNull(mapper.apply(value), "mapper result must not be null");
+    }
+
+    @Override
+    public Result<T> recover(Function<? super Throwable, ? extends T> recovery) {
+        Objects.requireNonNull(recovery, "recovery must not be null");
+        return this;
+    }
+}

--- a/src/main/java/io/github/amatriciaaana/kiora/result/Try.java
+++ b/src/main/java/io/github/amatriciaaana/kiora/result/Try.java
@@ -1,0 +1,36 @@
+package io.github.amatriciaaana.kiora.result;
+
+/**
+ * Factory methods for converting checked exception code into {@link Result} values.
+ */
+public final class Try {
+    private Try() {
+    }
+
+    public static <T> Result<T> of(CheckedSupplier<T> supplier) {
+        try {
+            return Result.success(supplier.get());
+        } catch (Throwable throwable) {
+            return Result.failure(throwable);
+        }
+    }
+
+    public static Result<Unit> run(CheckedRunnable runnable) {
+        try {
+            runnable.run();
+            return Result.success(Unit.INSTANCE);
+        } catch (Throwable throwable) {
+            return Result.failure(throwable);
+        }
+    }
+
+    @FunctionalInterface
+    public interface CheckedSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface CheckedRunnable {
+        void run() throws Exception;
+    }
+}

--- a/src/main/java/io/github/amatriciaaana/kiora/result/Unit.java
+++ b/src/main/java/io/github/amatriciaaana/kiora/result/Unit.java
@@ -1,0 +1,8 @@
+package io.github.amatriciaaana.kiora.result;
+
+/**
+ * Marker value for operations that complete successfully without returning data.
+ */
+public enum Unit {
+    INSTANCE
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,4 @@
 module io.github.amatriciaaana.kiora {
     exports io.github.amatriciaaana.kiora.path;
+    exports io.github.amatriciaaana.kiora.result;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module io.github.amatriciaaana.kiora {
+    exports io.github.amatriciaaana.kiora.optional;
     exports io.github.amatriciaaana.kiora.path;
     exports io.github.amatriciaaana.kiora.result;
 }

--- a/src/test/java/io/github/amatriciaaana/kiora/optional/MoreOptionalTest.java
+++ b/src/test/java/io/github/amatriciaaana/kiora/optional/MoreOptionalTest.java
@@ -1,0 +1,58 @@
+package io.github.amatriciaaana.kiora.optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.amatriciaaana.kiora.result.Result;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MoreOptionalTest {
+
+    @Test
+    void orUsesFallbackOnlyWhenEmpty() {
+        Optional<String> fallback = MoreOptional.or(Optional.empty(), () -> "guest");
+        Optional<String> existing = MoreOptional.or(Optional.of("aki"), () -> "guest");
+
+        assertEquals("guest", fallback.orElseThrow());
+        assertEquals("aki", existing.orElseThrow());
+    }
+
+    @Test
+    void filterNotRemovesMatchingValues() {
+        Optional<String> filtered = MoreOptional.filterNot(Optional.of(""), String::isBlank);
+        Optional<String> kept = MoreOptional.filterNot(Optional.of("aki"), String::isBlank);
+
+        assertTrue(filtered.isEmpty());
+        assertEquals("aki", kept.orElseThrow());
+    }
+
+    @Test
+    void toResultReturnsSuccessWhenPresent() {
+        Result<String> result = MoreOptional.toResult(Optional.of("aki"), () -> new NoSuchElementException("missing"));
+
+        assertTrue(result.isSuccess());
+        assertEquals("aki", result.orElseThrow());
+    }
+
+    @Test
+    void toResultReturnsFailureWhenEmpty() {
+        Result<String> result = MoreOptional.toResult(Optional.empty(), () -> new NoSuchElementException("missing"));
+
+        assertTrue(result.isFailure());
+        assertInstanceOf(NoSuchElementException.class, result.errorOrNull());
+    }
+
+    @Test
+    void streamOfNullableMatchesSingleOrEmptyStream() {
+        List<String> present = MoreOptional.streamOfNullable("aki").toList();
+        List<Object> empty = MoreOptional.streamOfNullable(null).toList();
+
+        assertEquals(List.of("aki"), present);
+        assertFalse(empty.iterator().hasNext());
+    }
+}

--- a/src/test/java/io/github/amatriciaaana/kiora/result/ResultTest.java
+++ b/src/test/java/io/github/amatriciaaana/kiora/result/ResultTest.java
@@ -1,0 +1,90 @@
+package io.github.amatriciaaana.kiora.result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class ResultTest {
+
+    @Test
+    void mapsSuccessfulValues() {
+        Result<Integer> result = Result.success(20)
+                .map(value -> value + 1)
+                .flatMap(value -> Result.success(value * 2));
+
+        assertTrue(result.isSuccess());
+        assertEquals(42, result.orElseThrow());
+    }
+
+    @Test
+    void keepsFailuresAcrossMapOperations() {
+        IOException cause = new IOException("disk");
+
+        Result<Integer> result = Result.<Integer>failure(cause)
+                .map(value -> value + 1)
+                .flatMap(value -> Result.success(value * 2));
+
+        assertTrue(result.isFailure());
+        assertEquals(cause, result.errorOrNull());
+        assertEquals(7, result.orElse(7));
+    }
+
+    @Test
+    void recoversFromFailure() {
+        Result<Integer> result = Result.<Integer>failure(new IOException("disk"))
+                .recover(error -> 42);
+
+        assertTrue(result.isSuccess());
+        assertEquals(42, result.orElseThrow());
+    }
+
+    @Test
+    void tryOfCapturesCheckedExceptions() {
+        Result<String> result = Try.of(() -> {
+            throw new IOException("boom");
+        });
+
+        assertTrue(result.isFailure());
+        assertInstanceOf(IOException.class, result.errorOrNull());
+    }
+
+    @Test
+    void tryRunReturnsUnitForVoidWork() {
+        Result<Unit> result = Try.run(() -> {
+        });
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.toOptional().isPresent());
+        assertEquals(Unit.INSTANCE, result.orElseThrow());
+    }
+
+    @Test
+    void failedCheckedExceptionWrapsIntoResultException() {
+        Result<String> result = Result.failure(new IOException("boom"));
+
+        ResultException exception = assertThrows(ResultException.class, result::orElseThrow);
+        assertInstanceOf(IOException.class, exception.getCause());
+    }
+
+    @Test
+    void failedRuntimeExceptionIsRethrownDirectly() {
+        IllegalStateException cause = new IllegalStateException("boom");
+        Result<String> result = Result.failure(cause);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, result::orElseThrow);
+        assertEquals(cause, exception);
+    }
+
+    @Test
+    void successfulNullValueStaysOptionalEmpty() {
+        Result<String> result = Result.success(null);
+
+        assertTrue(result.isSuccess());
+        assertFalse(result.toOptional().isPresent());
+    }
+}


### PR DESCRIPTION
## Summary
- add the new `io.github.amatriciaaana.kiora.optional` package
- implement `MoreOptional` helpers for common `Optional` boilerplate
- add unit tests for fallback, filtering, result conversion, and nullable streams
- export the package and document it in the README

## Why
- reduces repetitive `Optional` handling code
- complements the existing `result` package well
- expands `kiora` with another broadly useful utility module
