### PR TITLE
Rename packages to dev.kiora

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 The library currently includes three focused packages:
 
-- `io.github.amatriciaaana.kiora.path` for safe access to nested `Map<String, Object>` and `List<?>` structures
-- `io.github.amatriciaaana.kiora.result` for lightweight success/failure handling around exception-heavy code
-- `io.github.amatriciaaana.kiora.optional` for small `Optional` helpers that remove repeated boilerplate
+- `dev.kiora.path` for safe access to nested `Map<String, Object>` and `List<?>` structures
+- `dev.kiora.result` for lightweight success/failure handling around exception-heavy code
+- `dev.kiora.optional` for small `Optional` helpers that remove repeated boilerplate
 
 The longer-term direction is to keep `kiora` broad enough to host additional small utilities without turning it into a framework.
 
@@ -20,7 +20,7 @@ That setup keeps the project aligned with the latest LTS while remaining easy to
 ## Path Example
 
 ```java
-import io.github.amatriciaaana.kiora.path.DeepMap;
+import dev.kiora.path.DeepMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,8 +43,8 @@ boolean hasCoupon = deepMap.hasPath("items[0].coupon");
 ## Result Example
 
 ```java
-import io.github.amatriciaaana.kiora.result.Result;
-import io.github.amatriciaaana.kiora.result.Try;
+import dev.kiora.result.Result;
+import dev.kiora.result.Try;
 
 Result<Integer> parsed = Try.of(() -> Integer.parseInt("42"))
         .map(value -> value + 1);
@@ -55,8 +55,8 @@ int value = parsed.orElse(0);
 ## Optional Example
 
 ```java
-import io.github.amatriciaaana.kiora.optional.MoreOptional;
-import io.github.amatriciaaana.kiora.result.Result;
+import dev.kiora.optional.MoreOptional;
+import dev.kiora.result.Result;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -64,14 +64,6 @@ Optional<String> nickname = MoreOptional.or(Optional.empty(), () -> "guest");
 Optional<String> visible = MoreOptional.filterNot(nickname, String::isBlank);
 Result<String> required = MoreOptional.toResult(visible, () -> new NoSuchElementException("nickname"));
 ```
-
-## Optional API Surface
-
-- `MoreOptional.ofNullable(value)`
-- `MoreOptional.or(optional, fallbackSupplier)`
-- `MoreOptional.filterNot(optional, predicate)`
-- `MoreOptional.toResult(optional, errorSupplier)`
-- `MoreOptional.streamOfNullable(value)`
 
 ## Build
 

--- a/src/main/java/dev/kiora/optional/MoreOptional.java
+++ b/src/main/java/dev/kiora/optional/MoreOptional.java
@@ -1,6 +1,6 @@
-package io.github.amatriciaaana.kiora.optional;
+package dev.kiora.optional;
 
-import io.github.amatriciaaana.kiora.result.Result;
+import dev.kiora.result.Result;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;

--- a/src/main/java/dev/kiora/path/DeepMap.java
+++ b/src/main/java/dev/kiora/path/DeepMap.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.path;
+package dev.kiora.path;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;

--- a/src/main/java/dev/kiora/path/PathSyntaxException.java
+++ b/src/main/java/dev/kiora/path/PathSyntaxException.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.path;
+package dev.kiora.path;
 
 /**
  * Signals that a path string does not follow path syntax rules.

--- a/src/main/java/dev/kiora/path/PathTokenizer.java
+++ b/src/main/java/dev/kiora/path/PathTokenizer.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.path;
+package dev.kiora.path;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/dev/kiora/result/Failure.java
+++ b/src/main/java/dev/kiora/result/Failure.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.result;
+package dev.kiora.result;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/src/main/java/dev/kiora/result/Result.java
+++ b/src/main/java/dev/kiora/result/Result.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.result;
+package dev.kiora.result;
 
 import java.util.Optional;
 import java.util.function.Function;

--- a/src/main/java/dev/kiora/result/ResultException.java
+++ b/src/main/java/dev/kiora/result/ResultException.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.result;
+package dev.kiora.result;
 
 /**
  * Wraps checked exceptions when a failed result is converted back into a thrown exception.

--- a/src/main/java/dev/kiora/result/Success.java
+++ b/src/main/java/dev/kiora/result/Success.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.result;
+package dev.kiora.result;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/src/main/java/dev/kiora/result/Try.java
+++ b/src/main/java/dev/kiora/result/Try.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.result;
+package dev.kiora.result;
 
 /**
  * Factory methods for converting checked exception code into {@link Result} values.

--- a/src/main/java/dev/kiora/result/Unit.java
+++ b/src/main/java/dev/kiora/result/Unit.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.result;
+package dev.kiora.result;
 
 /**
  * Marker value for operations that complete successfully without returning data.

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module io.github.amatriciaaana.kiora {
-    exports io.github.amatriciaaana.kiora.optional;
-    exports io.github.amatriciaaana.kiora.path;
-    exports io.github.amatriciaaana.kiora.result;
+module dev.kiora {
+    exports dev.kiora.optional;
+    exports dev.kiora.path;
+    exports dev.kiora.result;
 }

--- a/src/test/java/dev/kiora/optional/MoreOptionalTest.java
+++ b/src/test/java/dev/kiora/optional/MoreOptionalTest.java
@@ -1,11 +1,11 @@
-package io.github.amatriciaaana.kiora.optional;
+package dev.kiora.optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.amatriciaaana.kiora.result.Result;
+import dev.kiora.result.Result;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;

--- a/src/test/java/dev/kiora/path/DeepMapTest.java
+++ b/src/test/java/dev/kiora/path/DeepMapTest.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.path;
+package dev.kiora.path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/dev/kiora/result/ResultTest.java
+++ b/src/test/java/dev/kiora/result/ResultTest.java
@@ -1,4 +1,4 @@
-package io.github.amatriciaaana.kiora.result;
+package dev.kiora.result;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
## Summary
- rename the existing `path`, `result`, and `optional` packages to `dev.kiora.*`
- update `module-info.java` to export the new package names from `module dev.kiora`
- refresh README examples and references to use the new imports

## Why
- shortens imports and package names for consumers
- keeps the package layout cleaner for future modules
- separates the package rename from later feature PRs like `text`