### PR TITLE
Add validate utilities module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 `kiora` is a Java utility library aimed at reducing repetitive code in everyday applications.
 
-The library currently includes four focused packages:
+The library currently includes five focused packages:
 
 - `dev.kiora.path` for safe access to nested `Map<String, Object>` and `List<?>` structures
 - `dev.kiora.result` for lightweight success/failure handling around exception-heavy code
 - `dev.kiora.optional` for small `Optional` helpers that remove repeated boilerplate
 - `dev.kiora.text` for null-safe text utilities around blank and empty strings
+- `dev.kiora.validate` for lightweight object validation that returns `Result<T>`
 
 The longer-term direction is to keep `kiora` broad enough to host additional small utilities without turning it into a framework.
 
@@ -84,6 +85,34 @@ boolean blank = Texts.isBlank(nickname);
 - `Texts.emptyToNull(value)`
 - `Texts.blankToDefault(value, fallback)`
 - `Texts.lines(value)`
+
+## Validate Example
+
+```java
+import dev.kiora.result.Result;
+import dev.kiora.validate.Validator;
+
+record User(String name, int age, String email) {}
+
+Result<User> result = Validator.of(new User("Aki", 20, "aki@example.com"))
+        .notBlank(User::name, "name")
+        .rangeInt(User::age, 18, 65, "age")
+        .notNull(User::email, "email")
+        .toResult();
+```
+
+## Validate API Surface
+
+- `Validator.of(value)`
+- `Validator.check(condition, message)`
+- `Validator.check(predicate, message)`
+- `Validator.notNull(fieldName)`
+- `Validator.notNull(extractor, fieldName)`
+- `Validator.notBlank(extractor, fieldName)`
+- `Validator.satisfies(extractor, predicate, message)`
+- `Validator.rangeInt(extractor, minInclusive, maxInclusive, fieldName)`
+- `Validator.errors()`
+- `Validator.toResult()`
 
 ## Build
 

--- a/src/main/java/dev/kiora/validate/ValidationException.java
+++ b/src/main/java/dev/kiora/validate/ValidationException.java
@@ -1,0 +1,17 @@
+package dev.kiora.validate;
+
+import java.util.List;
+
+public final class ValidationException extends IllegalArgumentException {
+
+    private final List<String> errors;
+
+    public ValidationException(List<String> errors) {
+        super(String.join(", ", List.copyOf(errors)));
+        this.errors = List.copyOf(errors);
+    }
+
+    public List<String> errors() {
+        return errors;
+    }
+}

--- a/src/main/java/dev/kiora/validate/Validator.java
+++ b/src/main/java/dev/kiora/validate/Validator.java
@@ -1,0 +1,78 @@
+package dev.kiora.validate;
+
+import dev.kiora.result.Result;
+import dev.kiora.text.Texts;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
+
+public final class Validator<T> {
+
+    private final T value;
+    private final List<String> errors;
+
+    private Validator(T value) {
+        this.value = value;
+        this.errors = new ArrayList<>();
+    }
+
+    public static <T> Validator<T> of(T value) {
+        return new Validator<>(value);
+    }
+
+    public Validator<T> check(boolean condition, String message) {
+        if (!condition) {
+            errors.add(message);
+        }
+        return this;
+    }
+
+    public Validator<T> check(Predicate<? super T> predicate, String message) {
+        return check(predicate.test(value), message);
+    }
+
+    public Validator<T> notNull(String fieldName) {
+        return check(value != null, fieldName + " must not be null");
+    }
+
+    public <V> Validator<T> notNull(Function<? super T, ? extends V> extractor, String fieldName) {
+        return check(extractor.apply(value) != null, fieldName + " must not be null");
+    }
+
+    public Validator<T> notBlank(Function<? super T, String> extractor, String fieldName) {
+        return check(!Texts.isBlank(extractor.apply(value)), fieldName + " must not be blank");
+    }
+
+    public <V> Validator<T> satisfies(
+            Function<? super T, ? extends V> extractor,
+            Predicate<? super V> predicate,
+            String message
+    ) {
+        return check(predicate.test(extractor.apply(value)), message);
+    }
+
+    public Validator<T> rangeInt(ToIntFunction<? super T> extractor, int minInclusive, int maxInclusive, String fieldName) {
+        int extracted = extractor.applyAsInt(value);
+        return check(
+                extracted >= minInclusive && extracted <= maxInclusive,
+                fieldName + " must be between " + minInclusive + " and " + maxInclusive
+        );
+    }
+
+    public boolean isValid() {
+        return errors.isEmpty();
+    }
+
+    public List<String> errors() {
+        return List.copyOf(errors);
+    }
+
+    public Result<T> toResult() {
+        if (isValid()) {
+            return Result.success(value);
+        }
+        return Result.failure(new ValidationException(errors));
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,4 +3,5 @@ module dev.kiora {
     exports dev.kiora.path;
     exports dev.kiora.result;
     exports dev.kiora.text;
+    exports dev.kiora.validate;
 }

--- a/src/test/java/dev/kiora/validate/ValidatorTest.java
+++ b/src/test/java/dev/kiora/validate/ValidatorTest.java
@@ -1,0 +1,74 @@
+package dev.kiora.validate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.kiora.result.Result;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ValidatorTest {
+
+    @Test
+    void returnsSuccessWhenAllChecksPass() {
+        User user = new User("Aki", 20, "aki@example.com");
+
+        Result<User> result = Validator.of(user)
+                .notNull(User::email, "email")
+                .notBlank(User::name, "name")
+                .rangeInt(User::age, 18, 65, "age")
+                .toResult();
+
+        assertTrue(result.isSuccess());
+        assertEquals(user, result.orElseThrow());
+    }
+
+    @Test
+    void collectsMultipleValidationErrors() {
+        Result<User> result = Validator.of(new User(" ", 12, null))
+                .notBlank(User::name, "name")
+                .rangeInt(User::age, 18, 65, "age")
+                .notNull(User::email, "email")
+                .toResult();
+
+        assertTrue(result.isFailure());
+
+        ValidationException error = assertInstanceOf(ValidationException.class, result.errorOrNull());
+        assertEquals(
+                List.of(
+                        "name must not be blank",
+                        "age must be between 18 and 65",
+                        "email must not be null"
+                ),
+                error.errors()
+        );
+    }
+
+    @Test
+    void supportsPredicateChecksOnWholeObject() {
+        Result<User> result = Validator.of(new User("Aki", 30, "example.com"))
+                .check(user -> user.email().contains("@"), "email must contain @")
+                .toResult();
+
+        assertTrue(result.isFailure());
+        assertEquals(List.of("email must contain @"), Validator.of(new User("Aki", 30, "example.com"))
+                .check(user -> user.email().contains("@"), "email must contain @")
+                .errors());
+    }
+
+    @Test
+    void exposesImmutableErrorsView() {
+        Validator<User> validator = Validator.of(new User(null, 20, null))
+                .notNull(User::name, "name");
+
+        List<String> errors = validator.errors();
+
+        assertEquals(List.of("name must not be null"), errors);
+        assertFalse(errors instanceof java.util.ArrayList);
+    }
+
+    private record User(String name, int age, String email) {
+    }
+}


### PR DESCRIPTION
## Summary
- add the new `dev.kiora.validate` package
- implement `Validator` and `ValidationException` for lightweight object validation
- return validation failures as `Result<T>` so the new package composes with `dev.kiora.result`
- add unit tests and README examples for the validation flow

## Why
- reduces repetitive input validation boilerplate
- fits the existing `result`, `optional`, and `text` utility packages naturally
- adds a lightweight validation layer without introducing framework dependencies

## Verification
- compile main sources with JDK 25 using `javac --release 17`
- run a small smoke test covering success and failure validation flows
- unit tests were added but not executed in this environment because Maven is not installed